### PR TITLE
Issue 11/update bug

### DIFF
--- a/scm.lua
+++ b/scm.lua
@@ -662,6 +662,7 @@ function scm:updateScript (name, sourceName)
         if self.scripts[i].name == name then
             updateObj.source[sourceName] = self.scripts[i].source[sourceName]
             updateObj.type = self.scripts[i].type
+            break
         end
     end
 

--- a/scm.lua
+++ b/scm.lua
@@ -477,9 +477,9 @@ function scm:downloadPastebin (sourceObject, code, targetDirectory, updateObj)
     end
 
     if sourceObject.type == "program" then
-        shell.run("pastebin", "get", code, sourceObject.name .. ".lua")
+        shell.run("pastebin", "get", code, sourceObject.name)
     else
-        shell.run("pastebin", "get", code, targetDirectory .. sourceObject.name .. ".lua")
+        shell.run("pastebin", "get", code, targetDirectory .. sourceObject.name)
     end
 
     return sourceObject, true
@@ -604,15 +604,15 @@ function scm:removeScript (name, keepScriptConfig)
     local o = {}
     local scriptType = nil
 
-    if keepScriptConfig ~= true then
-        for i = 1, #self.scripts, 1 do
-            if self.scripts[i].name ~= name then
-                table.insert(o, self.scripts[i])
-            else 
-                scriptType = self.scripts[i].type
-            end
+    for i = 1, #self.scripts, 1 do
+        if self.scripts[i].name ~= name then
+            table.insert(o, self.scripts[i])
+        else 
+            scriptType = self.scripts[i].type
         end
-
+    end
+    
+    if keepScriptConfig ~= true then
         self.scripts = o
         self:saveScripts()
     end


### PR DESCRIPTION
resolves #19 

- removes file extension from pastebin scripts
- fixes removeScript (type has only been set when the config would be deleted)

For testing:
1 - Install scm
`pastebin run 1kKZ8zTS`
`scm update`

2 - Install suicidePath
`scm add suicidePath@jh0kMxQc`

3 - Update suicidePath
`scm update suicidePath`

If it works then there should be no message with "File already exists".
"Script already exists" is ok, because the script will only be updated and not deleted entirely.